### PR TITLE
Turn off RTTI on non-MSVC builds to fix linker issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(MSVC)
   # Ignore 'unreferenced function with internal linkage'
   target_compile_options(joltc PRIVATE /wd4505)
 else()
-  target_compile_options(joltc PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(joltc PRIVATE -Wall -Wextra -Wpedantic -fno-rtti)
 endif()
 
 if (DOUBLE_PRECISION)


### PR DESCRIPTION
Jolt Physics turns off RTTI by default in their code starting in 5.1.0, so we should force it off when building for Clang and GCC so that our code is compatible.