### PR TITLE
Add PhysicsSystem::SetContactListener

### DIFF
--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -1157,6 +1157,8 @@ JPC_API void JPC_PhysicsSystem_DrawBodies(
 
 JPC_API void JPC_PhysicsSystem_SetSimShapeFilter(JPC_PhysicsSystem* self, const JPC_SimShapeFilter* inShapeFilter);
 
+JPC_API void JPC_PhysicsSystem_SetContactListener(JPC_PhysicsSystem* self, JPC_ContactListener* listener);
+
 #ifdef __cplusplus
 }
 #endif

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -2143,3 +2143,9 @@ JPC_API void JPC_PhysicsSystem_SetSimShapeFilter(
 {
 	to_jph(self)->SetSimShapeFilter(to_jph(inShapeFilter));
 }
+
+JPC_API void JPC_PhysicsSystem_SetContactListener(JPC_PhysicsSystem* self, JPC_ContactListener* listener)
+{
+	JPH::ContactListener* contactListener = reinterpret_cast<JPH::ContactListener*>(listener);
+	to_jph(self)->SetContactListener(contactListener);
+}


### PR DESCRIPTION
Hi,

I'm testing the lib for server-side collision detection and needed a way to register a contact listener. This PR adds [`PhysicsSystem::SetContactListener`](https://jrouwe.github.io/JoltPhysicsDocs/5.1.0/class_physics_system.html#ade7967ad5ff4a67d255cc6fb956943c8).

Thanks!