### PR TITLE
Add JobSystemSingleThreaded

### DIFF
--- a/HelloWorld/main.cpp
+++ b/HelloWorld/main.cpp
@@ -194,7 +194,7 @@ int main() {
 
 		printf("Step %d: Position = (%f, %f, %f), Velocity = (%f, %f, %f)\n", step, position.x, position.y, position.z, velocity.x, velocity.y, velocity.z);
 
-		JPC_PhysicsSystem_Update(physics_system, cDeltaTime, cCollisionSteps, temp_allocator, job_system);
+		JPC_PhysicsSystem_Update(physics_system, cDeltaTime, cCollisionSteps, temp_allocator, (JPC_JobSystem*) job_system);
 	}
 
 	JPC_BodyInterface_RemoveBody(body_interface, sphere_id);

--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -232,9 +232,11 @@ JPC_API JPC_TempAllocatorImpl* JPC_TempAllocatorImpl_new(uint size);
 JPC_API void JPC_TempAllocatorImpl_delete(JPC_TempAllocatorImpl* object);
 
 ////////////////////////////////////////////////////////////////////////////////
-// JobSystemThreadPool
+// JobSystem
 
+typedef struct JPC_JobSystem JPC_JobSystem;
 typedef struct JPC_JobSystemThreadPool JPC_JobSystemThreadPool;
+typedef struct JPC_JobSystemSingleThreaded JPC_JobSystemSingleThreaded;
 
 JPC_API JPC_JobSystemThreadPool* JPC_JobSystemThreadPool_new2(
 	uint inMaxJobs,
@@ -245,6 +247,9 @@ JPC_API JPC_JobSystemThreadPool* JPC_JobSystemThreadPool_new3(
 	int inNumThreads);
 
 JPC_API void JPC_JobSystemThreadPool_delete(JPC_JobSystemThreadPool* object);
+
+JPC_API JPC_JobSystemSingleThreaded* JPC_JobSystemSingleThreaded_new(uint inMaxJobs);
+JPC_API void JPC_JobSystemSingleThreaded_delete(JPC_JobSystemSingleThreaded* object);
 
 ////////////////////////////////////////////////////////////////////////////////
 // CollisionGroup and GroupFilter
@@ -1162,7 +1167,7 @@ JPC_API JPC_PhysicsUpdateError JPC_PhysicsSystem_Update(
 	float inDeltaTime,
 	int inCollisionSteps,
 	JPC_TempAllocatorImpl *inTempAllocator, // FIXME: un-specialize
-	JPC_JobSystemThreadPool *inJobSystem); // FIXME: un-specialize
+	JPC_JobSystem* inJobSystem);
 
 JPC_API void JPC_PhysicsSystem_AddConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);
 JPC_API void JPC_PhysicsSystem_RemoveConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -1,6 +1,8 @@
 #include <Jolt/Jolt.h>
 
 #include <Jolt/Core/Factory.h>
+#include <Jolt/Core/JobSystem.h>
+#include <Jolt/Core/JobSystemSingleThreaded.h>
 #include <Jolt/Core/JobSystemThreadPool.h>
 #include <Jolt/Core/TempAllocator.h>
 #include <Jolt/Physics/Body/BodyActivationListener.h>
@@ -105,8 +107,14 @@ OPAQUE_WRAPPER(JPC_NarrowPhaseQuery, JPH::NarrowPhaseQuery)
 OPAQUE_WRAPPER(JPC_TempAllocatorImpl, JPH::TempAllocatorImpl)
 DESTRUCTOR(JPC_TempAllocatorImpl)
 
+OPAQUE_WRAPPER(JPC_JobSystem, JPH::JobSystem)
+DESTRUCTOR(JPC_JobSystem)
+
 OPAQUE_WRAPPER(JPC_JobSystemThreadPool, JPH::JobSystemThreadPool)
 DESTRUCTOR(JPC_JobSystemThreadPool)
+
+OPAQUE_WRAPPER(JPC_JobSystemSingleThreaded, JPH::JobSystemSingleThreaded)
+DESTRUCTOR(JPC_JobSystemSingleThreaded)
 
 OPAQUE_WRAPPER(JPC_Shape, JPH::Shape)
 OPAQUE_WRAPPER(JPC_CompoundShape, JPH::CompoundShape)
@@ -336,6 +344,13 @@ JPC_API JPC_JobSystemThreadPool* JPC_JobSystemThreadPool_new3(
 	int inNumThreads)
 {
 	return to_jpc(new JPH::JobSystemThreadPool(inMaxJobs, inMaxBarriers, inNumThreads));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// JobSystemSingleThreaded
+
+JPC_API JPC_JobSystemSingleThreaded* JPC_JobSystemSingleThreaded_new(uint inMaxJobs) {
+	return to_jpc(new JPH::JobSystemSingleThreaded(inMaxJobs));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2166,7 +2181,7 @@ JPC_API JPC_PhysicsUpdateError JPC_PhysicsSystem_Update(
 	float inDeltaTime,
 	int inCollisionSteps,
 	JPC_TempAllocatorImpl *inTempAllocator,
-	JPC_JobSystemThreadPool *inJobSystem)
+	JPC_JobSystem *inJobSystem)
 {
 	auto res = to_jph(self)->Update(
 		inDeltaTime,


### PR DESCRIPTION
This PR adds bindings for [JobSystemSingleThreaded](https://jrouwe.github.io/JoltPhysics/class_job_system_single_threaded.html)

After profiling, we detected that `JobSystemThreadPool` was introducing unnecessary overhead for our use case. In tests, `JPC_PhysicsSystem_Update` time dropped from roughly ~1ms to ~105µs.