### PR TITLE
Expose JPH::PhysicsSystem::SetGravity / GetGravity

### DIFF
--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -1624,10 +1624,6 @@ JPC_API JPC_PhysicsUpdateError JPC_PhysicsSystem_Update(
 JPC_API void JPC_PhysicsSystem_AddConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);
 JPC_API void JPC_PhysicsSystem_RemoveConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);
 
-// TITAN PATCH (2026-05-08): expose JPH::PhysicsSystem::SetGravity /
-// GetGravity. Wraps the matching C++ methods 1:1; pending upstream PR
-// to SecondHalfGames/JoltC. Removing this hunk is safe once upstream
-// merges + we sync our fork.
 JPC_API void JPC_PhysicsSystem_SetGravity(JPC_PhysicsSystem* self, JPC_Vec3 inGravity);
 JPC_API JPC_Vec3 JPC_PhysicsSystem_GetGravity(const JPC_PhysicsSystem* self);
 

--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -1624,6 +1624,13 @@ JPC_API JPC_PhysicsUpdateError JPC_PhysicsSystem_Update(
 JPC_API void JPC_PhysicsSystem_AddConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);
 JPC_API void JPC_PhysicsSystem_RemoveConstraint(JPC_PhysicsSystem* self, JPC_Constraint* constraint);
 
+// TITAN PATCH (2026-05-08): expose JPH::PhysicsSystem::SetGravity /
+// GetGravity. Wraps the matching C++ methods 1:1; pending upstream PR
+// to SecondHalfGames/JoltC. Removing this hunk is safe once upstream
+// merges + we sync our fork.
+JPC_API void JPC_PhysicsSystem_SetGravity(JPC_PhysicsSystem* self, JPC_Vec3 inGravity);
+JPC_API JPC_Vec3 JPC_PhysicsSystem_GetGravity(const JPC_PhysicsSystem* self);
+
 JPC_API JPC_BodyInterface* JPC_PhysicsSystem_GetBodyInterface(JPC_PhysicsSystem* self);
 JPC_API const JPC_BodyLockInterface* JPC_PhysicsSystem_GetBodyLockInterface(JPC_PhysicsSystem* self);
 

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -3024,6 +3024,16 @@ JPC_API void JPC_PhysicsSystem_RemoveConstraint(JPC_PhysicsSystem* self, JPC_Con
 	to_jph(self)->RemoveConstraint(to_jph(constraint));
 }
 
+// TITAN PATCH (2026-05-08): expose JPH::PhysicsSystem::SetGravity /
+// GetGravity. Pending upstream PR to SecondHalfGames/JoltC.
+JPC_API void JPC_PhysicsSystem_SetGravity(JPC_PhysicsSystem* self, JPC_Vec3 inGravity) {
+	to_jph(self)->SetGravity(to_jph(inGravity));
+}
+
+JPC_API JPC_Vec3 JPC_PhysicsSystem_GetGravity(const JPC_PhysicsSystem* self) {
+	return to_jpc(to_jph(self)->GetGravity());
+}
+
 JPC_API JPC_BodyInterface* JPC_PhysicsSystem_GetBodyInterface(JPC_PhysicsSystem* self) {
 	return to_jpc(&to_jph(self)->GetBodyInterface());
 }

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -3024,8 +3024,6 @@ JPC_API void JPC_PhysicsSystem_RemoveConstraint(JPC_PhysicsSystem* self, JPC_Con
 	to_jph(self)->RemoveConstraint(to_jph(constraint));
 }
 
-// TITAN PATCH (2026-05-08): expose JPH::PhysicsSystem::SetGravity /
-// GetGravity. Pending upstream PR to SecondHalfGames/JoltC.
 JPC_API void JPC_PhysicsSystem_SetGravity(JPC_PhysicsSystem* self, JPC_Vec3 inGravity) {
 	to_jph(self)->SetGravity(to_jph(inGravity));
 }


### PR DESCRIPTION
## Summary

Adds C wrappers for `JPH::PhysicsSystem::SetGravity(Vec3Arg)` and `GetGravity()`, exposing per-system gravity control to JoltC consumers (joltc-sys, rolt, downstream Rust bindings, LuaJIT bindings, etc.).

## Motivation

Jolt's `PhysicsSystem` stores gravity internally and the integrator reads it every step. Without a C wrapper, consumers are locked to Jolt's default `(0, -9.81, 0)` and cannot implement gameplay features like low-gravity power-ups, alien-planet biomes, or per-region gravity overrides. Per-body `GravityFactor` is a scalar multiplier and cannot redirect gravity, so it does not substitute.

## Implementation

- `JoltC/JoltC/Functions.h` — declarations placed next to `AddConstraint`/`RemoveConstraint` (line ~1626).
- `JoltC/JoltCImpl/JoltC.cpp` — implementations using the existing `to_jph(self) -> JPH::PhysicsSystem*` + `to_jph(JPC_Vec3)` / `to_jpc(JPH::Vec3)` helper pattern (lines 162-167 of `JoltC.cpp`).

17 lines total. No allocations, no behavioral changes to existing APIs — purely additive.

## Test plan

- [x] CMake build succeeds with the new declarations on Windows + MSVC (author's local env).
- [x] Downstream Rust consumer (the Titan game engine's `titan-jolt-3d` crate, which vendors joltc-sys + rolt) calls `JPC_PhysicsSystem_SetGravity` per step; bodies accelerate along the supplied gravity vector. New unit test verifies `+X` gravity moves a body along `+X`.
- [ ] Cross-platform CMake build verified by reviewer (Linux + macOS).
- [x] No regressions in existing JoltC consumers — only adds new exports.

Opened from a downstream-vendoring fork; happy to address review feedback or split the change if preferred.