### PR TITLE
Expose JPH::PlaneShape via JPC_PlaneShapeSettings

### DIFF
--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -1160,6 +1160,23 @@ JPC_API void JPC_CylinderShapeSettings_default(JPC_CylinderShapeSettings* object
 JPC_API bool JPC_CylinderShapeSettings_Create(const JPC_CylinderShapeSettings* self, JPC_Shape** outShape, JPC_String** outError);
 
 ////////////////////////////////////////////////////////////////////////////////
+// PlaneShapeSettings -> ShapeSettings
+
+typedef struct JPC_PlaneShapeSettings {
+	// ShapeSettings
+	uint64_t UserData;
+
+	// PlaneShapeSettings
+	// TODO: Material
+	JPC_Vec3 Normal;
+	float Constant;
+	float HalfExtent;
+} JPC_PlaneShapeSettings;
+
+JPC_API void JPC_PlaneShapeSettings_default(JPC_PlaneShapeSettings* object);
+JPC_API bool JPC_PlaneShapeSettings_Create(const JPC_PlaneShapeSettings* self, JPC_Shape** outShape, JPC_String** outError);
+
+////////////////////////////////////////////////////////////////////////////////
 // ConvexHullShapeSettings -> ConvexShapeSettings -> ShapeSettings
 
 typedef struct JPC_ConvexHullShapeSettings {

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -21,6 +21,7 @@
 #include <Jolt/Physics/Collision/Shape/CylinderShape.h>
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/Collision/Shape/MutableCompoundShape.h>
+#include <Jolt/Physics/Collision/Shape/PlaneShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
 #include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
 #include <Jolt/Physics/Collision/Shape/TriangleShape.h>
@@ -1902,6 +1903,33 @@ JPC_API void JPC_CylinderShapeSettings_default(JPC_CylinderShapeSettings* object
 
 JPC_API bool JPC_CylinderShapeSettings_Create(const JPC_CylinderShapeSettings* self, JPC_Shape** outShape, JPC_String** outError) {
 	JPH::CylinderShapeSettings settings;
+	to_jph(self, &settings);
+
+	return HandleShapeResult(settings.Create(), outShape, outError);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PlaneShapeSettings
+
+static void to_jph(const JPC_PlaneShapeSettings* input, JPH::PlaneShapeSettings* output) {
+	output->mUserData = input->UserData;
+
+	// TODO: Material
+	output->mPlane = JPH::Plane(to_jph(input->Normal), input->Constant);
+	output->mHalfExtent = input->HalfExtent;
+}
+
+JPC_API void JPC_PlaneShapeSettings_default(JPC_PlaneShapeSettings* object) {
+	object->UserData = 0;
+
+	// TODO: Material
+	object->Normal = JPC_Vec3{0, 1, 0, 1};
+	object->Constant = 0.0;
+	object->HalfExtent = JPH::PlaneShapeSettings::cDefaultHalfExtent;
+}
+
+JPC_API bool JPC_PlaneShapeSettings_Create(const JPC_PlaneShapeSettings* self, JPC_Shape** outShape, JPC_String** outError) {
+	JPH::PlaneShapeSettings settings;
 	to_jph(self, &settings);
 
 	return HandleShapeResult(settings.Create(), outShape, outError);


### PR DESCRIPTION
## Problem

JoltC does not expose `JPH::PlaneShape` (the infinite-half-space collider; *"negative half space is solid"*). Downstream consumers that want a real halfspace primitive — for example mapping a `Halfspace { normal }` shape from a higher-level physics abstraction — have no choice but to approximate with a thin static box, which loses the authored normal direction and forces an arbitrary thickness offset.

## Fix

Add `JPC_PlaneShapeSettings` + matching `_default` / `_Create` exports following the same pattern as `JPC_BoxShapeSettings`, `JPC_SphereShapeSettings`, etc.

```c
typedef struct JPC_PlaneShapeSettings {
    // ShapeSettings
    uint64_t UserData;

    // PlaneShapeSettings
    // TODO: Material
    JPC_Vec3 Normal;
    float Constant;
    float HalfExtent;
} JPC_PlaneShapeSettings;

JPC_API void JPC_PlaneShapeSettings_default(JPC_PlaneShapeSettings* object);
JPC_API bool JPC_PlaneShapeSettings_Create(const JPC_PlaneShapeSettings* self, JPC_Shape** outShape, JPC_String** outError);
```

The C-side struct carries `Normal` + `Constant` rather than a `JPC_Plane` wrapper to avoid introducing a new binding type for a single use site; the C++ side constructs the `JPH::Plane` via its `Plane(Vec3 normal, float constant)` ctor. `Material` is stubbed with a `TODO` comment, consistent with every other `*ShapeSettings` in the codebase.

`HalfExtent` defaults to `JPH::PlaneShapeSettings::cDefaultHalfExtent` (1000.0f), matching JPH's own default.

## Constraint

`PlaneShape` MUST be static or kinematic per JPH (`PlaneShape::MustBeStatic() == true`). Caller's responsibility, same contract as `JoltPhysics/Samples/Tests/Shapes/PlaneShapeTest.cpp` upstream.

## Validation

Downstream verification: Titan engine's `titan-jolt-3d` plugin uses this binding to back its `BodyShape::Halfspace { normal }`. New integration test (`halfspace_authors_non_y_normal`) raycasts a non-+Y halfspace and asserts:
- ray distance lands on the authored plane (5 m for a 5-m offset along the plane normal)
- hit normal returned by Jolt's raycast matches the authored normal (dot product > 0.95 with the expected direction)

The same test against the prior thin-box approximation returned axis-aligned normals on the box faces, never the authored plane normal — concrete evidence that the new path actually exercises `PlaneShape::GetSurfaceNormal`.

## Test plan

- [x] Builds against current `main` on Windows host (msvc).
- [x] `JPC_PlaneShapeSettings_Create` returns a valid `JPC_Shape*` for a +Y normal at the origin.
- [x] Downstream raycast against the resulting body returns the authored normal.
- [ ] Material parameter — out of scope for this PR (left as `TODO` like every other shape).