### PR TITLE
Expose JPH::ShapeFilter::mBodyID2 to C via JPC_ShapeFilter_getBodyID2

### DIFF
--- a/JoltC/Functions.h
+++ b/JoltC/Functions.h
@@ -407,19 +407,21 @@ JPC_API void JPC_BodyFilter_delete(JPC_BodyFilter* object);
 ////////////////////////////////////////////////////////////////////////////////
 // ShapeFilter
 
-typedef struct JPC_ShapeFilterFns {
-	bool (*ShouldCollide)(const void *self, const JPC_Shape *inShape2, JPC_SubShapeID inSubShapeIDOfShape2);
+typedef struct JPC_ShapeFilter JPC_ShapeFilter;
 
-	bool (*ShouldCollideTwoShapes)(const void *self,
+typedef struct JPC_ShapeFilterFns {
+	bool (*ShouldCollide)(const void *self, const JPC_ShapeFilter *filter, const JPC_Shape *inShape2, JPC_SubShapeID inSubShapeIDOfShape2);
+
+	bool (*ShouldCollideTwoShapes)(const void *self, const JPC_ShapeFilter *filter,
 		const JPC_Shape *inShape1, JPC_SubShapeID inSubShapeIDOfShape1,
 		const JPC_Shape *inShape2, JPC_SubShapeID inSubShapeIDOfShape2);
 } JPC_ShapeFilterFns;
 
-typedef struct JPC_ShapeFilter JPC_ShapeFilter;
-
 JPC_API JPC_ShapeFilter* JPC_ShapeFilter_new(
 	const void *self,
 	JPC_ShapeFilterFns fns);
+
+JPC_API JPC_BodyID JPC_ShapeFilter_getBodyID2(const JPC_ShapeFilter* self);
 
 JPC_API void JPC_ShapeFilter_delete(JPC_ShapeFilter* object);
 

--- a/JoltCImpl/JoltC.cpp
+++ b/JoltCImpl/JoltC.cpp
@@ -598,7 +598,8 @@ public:
 			return true;
 		}
 
-		return fns.ShouldCollide(self, to_jpc(inShape2), to_jpc(inSubShapeIDOfShape2));
+		const JPC_ShapeFilter* filter = reinterpret_cast<const JPC_ShapeFilter*>(this);
+		return fns.ShouldCollide(self, filter, to_jpc(inShape2), to_jpc(inSubShapeIDOfShape2));
 	}
 
 	virtual bool ShouldCollide(
@@ -609,7 +610,8 @@ public:
 			return true;
 		}
 
-		return fns.ShouldCollideTwoShapes(self,
+		const JPC_ShapeFilter* filter = reinterpret_cast<const JPC_ShapeFilter*>(this);
+		return fns.ShouldCollideTwoShapes(self, filter,
 			to_jpc(inShape1), to_jpc(inSubShapeIDOfShape1),
 			to_jpc(inShape2), to_jpc(inSubShapeIDOfShape2));
 	}
@@ -627,6 +629,11 @@ JPC_API JPC_ShapeFilter* JPC_ShapeFilter_new(
 	JPC_ShapeFilterFns fns)
 {
 	return to_jpc(new JPC_ShapeFilterBridge(self, fns));
+}
+
+JPC_API JPC_BodyID JPC_ShapeFilter_getBodyID2(const JPC_ShapeFilter* self) {
+	const JPC_ShapeFilterBridge* filter = to_jph(self);
+	return to_jpc(filter->mBodyID2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
And pass a ShapeFilter pointer to the ShapeFilterFns to get at the ShapeFilter form inside the ShapeFilterFns

The motivation for implementing it this way instead of simply passing the body ID into ShapeFilterFns is that the C API should support creating a ShapeFilter with `JPC_ShapeFilter_new` and read the body from it independently of the ShapeFilterFns. Also if JPH::ShapeFilter has members added in the future this won't bloat the ShapeFilterFns signatures.

```c
reinterpret_cast<const JPC_ShapeFilter*>(this)
```
instead of 
```c
 to_jpc(this)
```
because the `OPAQUE_WRAPPER(JPC_ShapeFilter, JPC_ShapeFilterBridge)` is invoked after the JPC_ShapeFilterBridge definition so we can't use it.